### PR TITLE
[DEV] Preference Util 구성

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -51,6 +51,10 @@ kotlin {
             implementation("cafe.adriel.voyager:voyager-navigator:$voyagerVersion")
             implementation("cafe.adriel.voyager:voyager-screenmodel:$voyagerVersion")
             implementation("cafe.adriel.voyager:voyager-tab-navigator:${voyagerVersion}")
+
+            // Datastore Preference
+            implementation(libs.androidx.datastore)
+            implementation(libs.androidx.datastore.preferences)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/com/yong/taximeter/common/PreferenceUtil.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/yong/taximeter/common/PreferenceUtil.android.kt
@@ -1,0 +1,21 @@
+package com.yong.taximeter.common
+
+actual class PreferenceManager {
+    actual suspend fun getString(key: String, defaultValue: String): String {
+        // TODO: String Get 로직 구현
+        return defaultValue
+    }
+
+    actual suspend fun putString(key: String, value: String) {
+        // TODO: String Put 로직 구현
+    }
+
+    actual suspend fun getInt(key: String, defaultValue: Int): Int {
+        // TODO: Int Get 로직 구현
+        return defaultValue
+    }
+
+    actual suspend fun putInt(key: String, value: Int) {
+        // TODO: Int Put 로직 구현
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/yong/taximeter/common/PreferenceUtil.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/yong/taximeter/common/PreferenceUtil.android.kt
@@ -1,21 +1,37 @@
 package com.yong.taximeter.common
 
-actual class PreferenceManager {
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore by preferencesDataStore("app_preferences")
+
+actual class PreferenceManager(private val context: Context) {
     actual suspend fun getString(key: String, defaultValue: String): String {
-        // TODO: String Get 로직 구현
-        return defaultValue
+        return context.dataStore.data.map { preferences ->
+            preferences[stringPreferencesKey(key)] ?: defaultValue
+        }.first()
     }
 
     actual suspend fun putString(key: String, value: String) {
-        // TODO: String Put 로직 구현
+        context.dataStore.edit { preferences ->
+            preferences[stringPreferencesKey(key)] = value
+        }
     }
 
     actual suspend fun getInt(key: String, defaultValue: Int): Int {
-        // TODO: Int Get 로직 구현
-        return defaultValue
+        return context.dataStore.data.map { preferences ->
+            preferences[intPreferencesKey(key)] ?: defaultValue
+        }.first()
     }
 
     actual suspend fun putInt(key: String, value: Int) {
-        // TODO: Int Put 로직 구현
+        context.dataStore.edit { preferences ->
+            preferences[intPreferencesKey(key)] = value
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/yong/taximeter/common/PreferenceUtil.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/yong/taximeter/common/PreferenceUtil.android.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.map
 
 private val Context.dataStore by preferencesDataStore("app_preferences")
 
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual class PreferenceManager(private val context: Context) {
     actual suspend fun getString(key: String, defaultValue: String): String {
         return context.dataStore.data.map { preferences ->

--- a/composeApp/src/commonMain/kotlin/com/yong/taximeter/common/PreferenceUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/yong/taximeter/common/PreferenceUtil.kt
@@ -1,0 +1,21 @@
+package com.yong.taximeter.common
+
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+object PreferenceUtil: KoinComponent {
+    private val manager: PreferenceManager by inject()
+
+    suspend fun getString(key: String, defaultValue: String) = manager.getString(key, defaultValue)
+    suspend fun putString(key: String, value: String) = manager.putString(key, value)
+    suspend fun getInt(key: String, defaultValue: Int) = manager.getInt(key, defaultValue)
+    suspend fun putInt(key: String, value: Int) = manager.putInt(key, value)
+}
+
+expect class PreferenceManager {
+    suspend fun getString(key: String, defaultValue: String): String
+    suspend fun putString(key: String, value: String)
+
+    suspend fun getInt(key: String, defaultValue: Int): Int
+    suspend fun putInt(key: String, value: Int)
+}

--- a/composeApp/src/iosMain/kotlin/com/yong/taximeter/common/PreferenceUtil.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/yong/taximeter/common/PreferenceUtil.ios.kt
@@ -3,6 +3,7 @@ package com.yong.taximeter.common
 import platform.Foundation.NSUserDefaults
 import platform.Foundation.setValue
 
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual class PreferenceManager {
     private val userDefaults = NSUserDefaults.standardUserDefaults
 

--- a/composeApp/src/iosMain/kotlin/com/yong/taximeter/common/PreferenceUtil.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/yong/taximeter/common/PreferenceUtil.ios.kt
@@ -1,21 +1,28 @@
 package com.yong.taximeter.common
 
+import platform.Foundation.NSUserDefaults
+import platform.Foundation.setValue
+
 actual class PreferenceManager {
+    private val userDefaults = NSUserDefaults.standardUserDefaults
+
     actual suspend fun getString(key: String, defaultValue: String): String {
-        // TODO: String Get 로직 구현
-        return defaultValue
+        return userDefaults.stringForKey(key) ?: defaultValue
     }
 
     actual suspend fun putString(key: String, value: String) {
-        // TODO: String Put 로직 구현
+        userDefaults.setValue(value, forKey = key)
     }
 
     actual suspend fun getInt(key: String, defaultValue: Int): Int {
-        // TODO: Int Get 로직 구현
-        return defaultValue
+        return if (userDefaults.objectForKey(key) != null) {
+            userDefaults.integerForKey(key).toInt()
+        } else {
+            defaultValue
+        }
     }
 
     actual suspend fun putInt(key: String, value: Int) {
-        // TODO: Int Put 로직 구현
+        userDefaults.setInteger(value.toLong(), forKey = key)
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/yong/taximeter/common/PreferenceUtil.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/yong/taximeter/common/PreferenceUtil.ios.kt
@@ -1,0 +1,21 @@
+package com.yong.taximeter.common
+
+actual class PreferenceManager {
+    actual suspend fun getString(key: String, defaultValue: String): String {
+        // TODO: String Get 로직 구현
+        return defaultValue
+    }
+
+    actual suspend fun putString(key: String, value: String) {
+        // TODO: String Put 로직 구현
+    }
+
+    actual suspend fun getInt(key: String, defaultValue: Int): Int {
+        // TODO: Int Get 로직 구현
+        return defaultValue
+    }
+
+    actual suspend fun putInt(key: String, value: Int) {
+        // TODO: Int Put 로직 구현
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,24 +4,13 @@ android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
 androidx-activity = "1.11.0"
-androidx-appcompat = "1.7.1"
-androidx-core = "1.17.0"
-androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.4"
-androidx-testExt = "1.3.0"
 composeMultiplatform = "1.9.0"
 datastore = "1.1.7"
-junit = "4.13.2"
 kotlin = "2.2.20"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-junit = { module = "junit:junit", version.ref = "junit" }
-androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
-androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
-androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.4"
 androidx-testExt = "1.3.0"
 composeMultiplatform = "1.9.0"
+datastore = "1.1.7"
 junit = "4.13.2"
 kotlin = "2.2.20"
 
@@ -24,6 +25,8 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
App의 Preference를 관리할 Util을 구성하였습니다.

## Description
- App Preference를 통합해서 관리할 Util을 구성하였습니다.
- Common Module에서는 `Preference Util`을 사용하며, 내부에서 자체적으로 `Preference Manager`를 호출합니다.
- `Preference Manager`는 Expect-Actual 패턴을 기반으로 Android, iOS 각 플랫폼의 Manager를 호출합니다.
- Android에서는 AndroidX Datastore를 기반으로 구현하였습니다.
- iOS에서는 NSUserDefaults를 기반으로 구현하였습니다.